### PR TITLE
chore: fix supabase client to have types instead of any on dashboard

### DIFF
--- a/apps/dashboard/src/lib/supabase/supabase-types.ts
+++ b/apps/dashboard/src/lib/supabase/supabase-types.ts
@@ -1,4 +1,4 @@
-import type { Database } from "../../types/database.types";
+import type { Database } from '../../types/database.types';
 
 export type URLInfo = Database['public']['Tables']['urls']['Row'];
 export type LinkInfo = Database['public']['Tables']['dynamic_links']['Row'];

--- a/apps/dashboard/src/routes/+layout.ts
+++ b/apps/dashboard/src/routes/+layout.ts
@@ -2,11 +2,12 @@ import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/publi
 import { createSupabaseLoadClient } from '@supabase/auth-helpers-sveltekit';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
+import type { Database } from '../types/database.types';
 
 export const load: LayoutLoad = async ({ fetch, data, depends }) => {
 	depends('supabase:auth');
 
-	const supabase = createSupabaseLoadClient({
+	const supabase = createSupabaseLoadClient<Database>({
 		supabaseUrl: PUBLIC_SUPABASE_URL,
 		supabaseKey: PUBLIC_SUPABASE_ANON_KEY,
 		event: { fetch },


### PR DESCRIPTION
![Screenshot 2023-08-14 at 6 19 36 PM](https://github.com/chandertech/turtlelinks/assets/7351329/14974ffd-4fca-4bbb-ad92-80f09aae90e5)

Typing the Supabase Client with the generated Database type gives us full type safety on all queries.